### PR TITLE
init: Move make_item to create_item

### DIFF
--- a/worlds/adofai/__init__.py
+++ b/worlds/adofai/__init__.py
@@ -89,22 +89,21 @@ class ADOFAIWorld(World):
             if loc_name not in adofai_locations.keys():
                 add_rule(loc, lambda state, ln=loc_name: state.has(f"Key_Level_{ln}", self.player))
 
+    def create_item(self, name: str) -> Item:
+        data = all_items[name]
+        cls = {
+            "progression": ItemClassification.progression,
+            "useful": ItemClassification.useful,
+            "filler": ItemClassification.filler,
+            "trap": ItemClassification.trap,
+        }.get(data.classification, ItemClassification.filler)
+        return Item(name, cls, data.id, self.player)
 
     def create_items(self) -> None:
         """Construit l'itempool: progression + useful, puis filler jusqu'à couvrir toutes les locations.
         Je dois utiliser les options pour créer le pool d'item
         """
         self.generate_early()
-
-        def make_item(name: str) -> Item:
-            data = all_items[name]
-            cls = {
-                "progression": ItemClassification.progression,
-                "useful": ItemClassification.useful,
-                "filler": ItemClassification.filler,
-                "trap": ItemClassification.trap,
-            }.get(data.classification, ItemClassification.filler)
-            return Item(name, cls, data.id, self.player)
 
         used_items = adofai_items | MainWorldsKeys
 
@@ -138,7 +137,7 @@ class ADOFAIWorld(World):
             used_items.update(AprilFoolsWorldsKeys)
 
         for item_name in used_items.keys():
-            self.multiworld.itempool.append(make_item(item_name))
+            self.multiworld.itempool.append(self.create_item(item_name))
         
         total_locations = len([
             loc for loc in self.multiworld.get_locations(self.player)


### PR DESCRIPTION
Moves `ADOFAIWorld.create_items.make_item` to `ADOFAIWorld.create_item` to satisfy `pytest test/general`.
Now passes `test_create_item` and `test_item_links`.
```Diff 
================================================================================== short test summary info ================================================================================== 
FAILED test/general/test_implemented.py::TestImplemented::test_completion_condition - AssertionError: True is not false
- FAILED test/general/test_items.py::TestBase::test_create_item - NotImplementedError
- FAILED test/general/test_items.py::TestBase::test_item_links - NotImplementedError
FAILED test/general/test_options.py::TestOptions::test_options_have_doc_string - AssertionError: None is not true
FAILED test/general/test_packages.py::TestPackages::test_packages_have_init - AssertionError: False != True
```
Still passes 1000 rounds of [Archipelago fuzzer.](https://github.com/Eijebong/Archipelago-fuzzer): `fuzz.py -g adofai -r 1000`